### PR TITLE
View Frustum Culling

### DIFF
--- a/src/game_renderer/GameRenderer.cpp
+++ b/src/game_renderer/GameRenderer.cpp
@@ -122,7 +122,7 @@ void GameRenderer::Render(std::shared_ptr<GameState> game_state) {
   P->perspective(45.0f, aspect, 0.01f, 100.0f);
   V.pushMatrix();
 
-  vec4 *vfplane = ViewFrustumCulling::GetViewFrustumPlanes(P->topMatrix(), V.topMatrix());
+  std::shared_ptr<std::vector<glm::vec4>> vfplane = ViewFrustumCulling::GetViewFrustumPlanes(P->topMatrix(), V.topMatrix());
 
   std::shared_ptr<Program> current_program = programs["platform_prog"];
   current_program->bind();
@@ -158,7 +158,6 @@ void GameRenderer::Render(std::shared_ptr<GameState> game_state) {
 
   glfwSwapBuffers(this->window);
   glfwPollEvents();
-  free(vfplane);
   if (game_state->Done()) {
     glfwSetWindowShouldClose(window, GL_TRUE);
   }

--- a/src/game_renderer/GameRenderer.cpp
+++ b/src/game_renderer/GameRenderer.cpp
@@ -13,6 +13,7 @@
 #include "LevelGenerator.h"
 #include "Platform.h"
 #include "InputBindings.h"
+#include "ViewFrustumCulling.h"
 
 GameRenderer::GameRenderer() {}
 
@@ -102,123 +103,6 @@ void GameRenderer::Init(const std::string& resource_dir,
   }
 }
 
-#define LEFT 0
-#define RIGHT 1
-#define BOTTOM 2
-#define TOP 3
-#define NEAR 4
-#define FAR 5
-
-vec4 * GetViewFrustumPlanes(mat4 P, mat4 V) {
-  vec4 Left, Right, Bottom, Top, Near, Far;
-  vec4 *planes = (vec4 *)malloc(sizeof(vec4) * 6);
-  vec3 normal;
-  float normal_length;
- 
-  mat4 comp = P * V;
-  
-  Left.x = comp[0][3] + comp[0][0]; // see handout to fill in with values from comp
-  Left.y = comp[1][3] + comp[1][0]; // see handout to fill in with values from comp
-  Left.z = comp[2][3] + comp[2][0]; // see handout to fill in with values from comp
-  Left.w = comp[3][3] + comp[3][0]; // see handout to fill in with values from comp
-  normal = vec3(Left.x, Left.y, Left.z);
-  normal_length = glm::length(normal);
-  planes[0] = Left/normal_length;
-  Left = Left/normal_length;
-
-  Right.x = comp[0][3] - comp[0][0]; // see handout to fill in with values from comp
-  Right.y = comp[1][3] - comp[1][0]; // see handout to fill in with values from comp
-  Right.z = comp[2][3] - comp[2][0]; // see handout to fill in with values from comp
-  Right.w = comp[3][3] - comp[3][0]; // see handout to fill in with values from comp
-  normal = vec3(Right.x, Right.y, Right.z);
-  normal_length = glm::length(normal);
-  planes[1] = Right/normal_length;
-  Right = Right/normal_length;
-
-  Bottom.x = comp[0][3] + comp[0][1]; // see handout to fill in with values from comp
-  Bottom.y = comp[1][3] + comp[1][1]; // see handout to fill in with values from comp
-  Bottom.z = comp[2][3] + comp[2][1]; // see handout to fill in with values from comp
-  Bottom.w = comp[3][3] + comp[3][1]; // see handout to fill in with values from comp
-  normal = vec3(Bottom.x, Bottom.y, Bottom.z);
-  normal_length = glm::length(normal);
-  planes[2] = Bottom/normal_length;
-  Bottom = Bottom/normal_length;
-
-  Top.x = comp[0][3] - comp[0][1]; // see handout to fill in with values from comp
-  Top.y = comp[1][3] - comp[1][1]; // see handout to fill in with values from comp
-  Top.z = comp[2][3] - comp[2][1]; // see handout to fill in with values from comp
-  Top.w = comp[3][3] - comp[3][1]; // see handout to fill in with values from comp
-  normal = vec3(Top.x, Top.y, Top.z);
-  normal_length = glm::length(normal);
-  planes[3] = Top/normal_length;
-  Top = Top/normal_length;
-
-  Near.x = comp[0][3] + comp[0][2]; // see handout to fill in with values from comp
-  Near.y = comp[1][3] + comp[1][2]; // see handout to fill in with values from comp
-  Near.z = comp[2][3] + comp[2][2]; // see handout to fill in with values from comp
-  Near.w = comp[3][3] + comp[3][2]; // see handout to fill in with values from comp
-  normal = vec3(Near.x, Near.y, Near.z);
-  normal_length = glm::length(normal);
-  planes[4] = Near/normal_length;
-  Near = Near/normal_length;
-
-  Far.x = comp[0][3] - comp[0][2]; // see handout to fill in with values from comp
-  Far.y = comp[1][3] - comp[1][2]; // see handout to fill in with values from comp
-  Far.z = comp[2][3] - comp[2][2]; // see handout to fill in with values from comp
-  Far.w = comp[3][3] - comp[3][2]; // see handout to fill in with values from comp
-  normal = vec3(Far.x, Far.y, Far.z);
-  normal_length = glm::length(normal);
-  planes[5] = Far/normal_length;
-  Far = Far/normal_length;
-
-  return planes;
-}
-
-float DistToPlane(float A, float B, float C, float D, vec3 point) {
-  return (A * point.x + B * point.y + C * point.z + D);
-}
-
-bool IsCulled(AxisAlignedBox box, vec4 * planes) {
-  float dist;
-  // If the max point is on the left side of the plane, cull
-  dist = DistToPlane(planes[LEFT].x, planes[LEFT].y, planes[LEFT].z, planes[LEFT].w, box.GetMax());
-  if (dist <= 0) {
-    return true;
-  }
-
-  // If the min point is on the right side of the plane, cull
-  dist = DistToPlane(planes[RIGHT].x, planes[RIGHT].y, planes[RIGHT].z, planes[RIGHT].w, box.GetMin());
-  if (dist <= 0) {
-    return true;
-  }
-
-  // If the min point is above the plane, cull
-  dist = DistToPlane(planes[TOP].x, planes[TOP].y, planes[TOP].z, planes[TOP].w, box.GetMin());
-  if (dist <= 0) {
-    return true;
-  }
-
-  // If the max point is below the plane, cull
-  dist = DistToPlane(planes[BOTTOM].x, planes[BOTTOM].y, planes[BOTTOM].z, planes[BOTTOM].w, box.GetMax());
-  if (dist <= 0) {
-    return true;
-  }
-
-  // If the max point is in front of the plane, cull
-  dist = DistToPlane(planes[NEAR].x, planes[NEAR].y, planes[NEAR].z, planes[NEAR].w, box.GetMax());
-  if (dist <= 0) {
-    return true;
-  }
-
-  // If the min point is in behind the plane, cull
-  dist = DistToPlane(planes[FAR].x, planes[FAR].y, planes[FAR].z, planes[FAR].w, box.GetMax());
-  if (dist <= 0) {
-    return true;
-  }
-
-  return false;
-} 
-
 void GameRenderer::Render(std::shared_ptr<GameState> game_state) {
   std::shared_ptr<Level> level = game_state->GetLevel();
   std::shared_ptr<GameCamera> camera = game_state->GetCamera();
@@ -238,7 +122,7 @@ void GameRenderer::Render(std::shared_ptr<GameState> game_state) {
   P->perspective(45.0f, aspect, 0.01f, 100.0f);
   V.pushMatrix();
 
-  vec4 *vfplane = GetViewFrustumPlanes(P->topMatrix(), V.topMatrix());
+  vec4 *vfplane = ViewFrustumCulling::GetViewFrustumPlanes(P->topMatrix(), V.topMatrix());
 
   std::shared_ptr<Program> current_program = programs["platform_prog"];
   current_program->bind();
@@ -248,7 +132,7 @@ void GameRenderer::Render(std::shared_ptr<GameState> game_state) {
                      glm::value_ptr(V.topMatrix()));
 
   for (std::shared_ptr<Platform> platform : *level->getLevel()) {
-    if (!IsCulled(platform->GetBoundingBox(), vfplane)) {
+    if (!ViewFrustumCulling::IsCulled(platform->GetBoundingBox(), vfplane)) {
       MV = platform->GetTransform();
       glUniformMatrix4fv(current_program->getUniform("MV"), 1, GL_FALSE,
                          glm::value_ptr(MV.topMatrix()));

--- a/src/game_renderer/GameRenderer.cpp
+++ b/src/game_renderer/GameRenderer.cpp
@@ -122,7 +122,8 @@ void GameRenderer::Render(std::shared_ptr<GameState> game_state) {
   P->perspective(45.0f, aspect, 0.01f, 100.0f);
   V.pushMatrix();
 
-  std::shared_ptr<std::vector<glm::vec4>> vfplane = ViewFrustumCulling::GetViewFrustumPlanes(P->topMatrix(), V.topMatrix());
+  std::shared_ptr<std::vector<glm::vec4>> vfplane =
+      ViewFrustumCulling::GetViewFrustumPlanes(P->topMatrix(), V.topMatrix());
 
   std::shared_ptr<Program> current_program = programs["platform_prog"];
   current_program->bind();

--- a/src/game_renderer/GameRenderer.cpp
+++ b/src/game_renderer/GameRenderer.cpp
@@ -158,6 +158,7 @@ void GameRenderer::Render(std::shared_ptr<GameState> game_state) {
 
   glfwSwapBuffers(this->window);
   glfwPollEvents();
+  free(vfplane);
   if (game_state->Done()) {
     glfwSetWindowShouldClose(window, GL_TRUE);
   }

--- a/src/game_renderer/ViewFrustumCulling.cpp
+++ b/src/game_renderer/ViewFrustumCulling.cpp
@@ -1,116 +1,120 @@
 #include "ViewFrustumCulling.h"
 
+#include <iostream>
+
 namespace ViewFrustumCulling {
 
-   // Code from CPE-476 lab
-   glm::vec4 * GetViewFrustumPlanes(glm::mat4 P, glm::mat4 V) {
-     glm::vec4 Left, Right, Bottom, Top, Near, Far;
-     glm::vec4 *planes = (glm::vec4 *)malloc(sizeof(glm::vec4) * 6);
-     glm::vec3 normal;
-     float normal_length;
-    
-     glm::mat4 comp = P * V;
+  // Code from CPE-476 lab
+  std::shared_ptr<std::vector<glm::vec4>> GetViewFrustumPlanes(glm::mat4 P, glm::mat4 V) {
+    glm::vec4 Left, Right, Bottom, Top, Near, Far;
+    std::shared_ptr<std::vector<glm::vec4>> planes =
+      std::make_shared<std::vector<glm::vec4>>();
+    planes->reserve(6);
+    glm::vec3 normal;
+    float normal_length;
+
+    glm::mat4 comp = P * V;
      
-     Left.x = comp[0][3] + comp[0][0];
-     Left.y = comp[1][3] + comp[1][0];
-     Left.z = comp[2][3] + comp[2][0];
-     Left.w = comp[3][3] + comp[3][0];
-     normal = glm::vec3(Left.x, Left.y, Left.z);
-     normal_length = glm::length(normal);
-     planes[0] = Left/normal_length;
-     Left = Left/normal_length;
+    Left.x = comp[0][3] + comp[0][0];
+    Left.y = comp[1][3] + comp[1][0];
+    Left.z = comp[2][3] + comp[2][0];
+    Left.w = comp[3][3] + comp[3][0];
+    normal = glm::vec3(Left.x, Left.y, Left.z);
+    normal_length = glm::length(normal);
+    planes->push_back(Left/normal_length);
+    Left = Left/normal_length;
+    
+    Right.x = comp[0][3] - comp[0][0];
+    Right.y = comp[1][3] - comp[1][0];
+    Right.z = comp[2][3] - comp[2][0];
+    Right.w = comp[3][3] - comp[3][0];
+    normal = glm::vec3(Right.x, Right.y, Right.z);
+    normal_length = glm::length(normal);
+    planes->push_back(Right/normal_length);
+    Right = Right/normal_length;
 
-     Right.x = comp[0][3] - comp[0][0];
-     Right.y = comp[1][3] - comp[1][0];
-     Right.z = comp[2][3] - comp[2][0];
-     Right.w = comp[3][3] - comp[3][0];
-     normal = glm::vec3(Right.x, Right.y, Right.z);
-     normal_length = glm::length(normal);
-     planes[1] = Right/normal_length;
-     Right = Right/normal_length;
+    Bottom.x = comp[0][3] + comp[0][1];
+    Bottom.y = comp[1][3] + comp[1][1];
+    Bottom.z = comp[2][3] + comp[2][1];
+    Bottom.w = comp[3][3] + comp[3][1];
+    normal = glm::vec3(Bottom.x, Bottom.y, Bottom.z);
+    normal_length = glm::length(normal);
+    planes->push_back(Bottom/normal_length);
+    Bottom = Bottom/normal_length;
 
-     Bottom.x = comp[0][3] + comp[0][1];
-     Bottom.y = comp[1][3] + comp[1][1];
-     Bottom.z = comp[2][3] + comp[2][1];
-     Bottom.w = comp[3][3] + comp[3][1];
-     normal = glm::vec3(Bottom.x, Bottom.y, Bottom.z);
-     normal_length = glm::length(normal);
-     planes[2] = Bottom/normal_length;
-     Bottom = Bottom/normal_length;
+    Top.x = comp[0][3] - comp[0][1];
+    Top.y = comp[1][3] - comp[1][1];
+    Top.z = comp[2][3] - comp[2][1];
+    Top.w = comp[3][3] - comp[3][1];
+    normal = glm::vec3(Top.x, Top.y, Top.z);
+    normal_length = glm::length(normal);
+    planes->push_back(Top/normal_length);
+    Top = Top/normal_length;
 
-     Top.x = comp[0][3] - comp[0][1];
-     Top.y = comp[1][3] - comp[1][1];
-     Top.z = comp[2][3] - comp[2][1];
-     Top.w = comp[3][3] - comp[3][1];
-     normal = glm::vec3(Top.x, Top.y, Top.z);
-     normal_length = glm::length(normal);
-     planes[3] = Top/normal_length;
-     Top = Top/normal_length;
+    Near.x = comp[0][3] + comp[0][2];
+    Near.y = comp[1][3] + comp[1][2];
+    Near.z = comp[2][3] + comp[2][2];
+    Near.w = comp[3][3] + comp[3][2];
+    normal = glm::vec3(Near.x, Near.y, Near.z);
+    normal_length = glm::length(normal);
+    planes->push_back(Near/normal_length);
+    Near = Near/normal_length;
 
-     Near.x = comp[0][3] + comp[0][2];
-     Near.y = comp[1][3] + comp[1][2];
-     Near.z = comp[2][3] + comp[2][2];
-     Near.w = comp[3][3] + comp[3][2];
-     normal = glm::vec3(Near.x, Near.y, Near.z);
-     normal_length = glm::length(normal);
-     planes[4] = Near/normal_length;
-     Near = Near/normal_length;
+    Far.x = comp[0][3] - comp[0][2];
+    Far.y = comp[1][3] - comp[1][2];
+    Far.z = comp[2][3] - comp[2][2];
+    Far.w = comp[3][3] - comp[3][2];
+    normal = glm::vec3(Far.x, Far.y, Far.z);
+    normal_length = glm::length(normal);
+    planes->push_back(Far/normal_length);
+    Far = Far/normal_length;
 
-     Far.x = comp[0][3] - comp[0][2];
-     Far.y = comp[1][3] - comp[1][2];
-     Far.z = comp[2][3] - comp[2][2];
-     Far.w = comp[3][3] - comp[3][2];
-     normal = glm::vec3(Far.x, Far.y, Far.z);
-     normal_length = glm::length(normal);
-     planes[5] = Far/normal_length;
-     Far = Far/normal_length;
+    return planes;   
+  }
 
-     return planes;
-   }
+  float DistToPlane(float A, float B, float C, float D, glm::vec3 point) {
+    return (A * point.x + B * point.y + C * point.z + D);
+  }
 
-   float DistToPlane(float A, float B, float C, float D, glm::vec3 point) {
-     return (A * point.x + B * point.y + C * point.z + D);
-   }
+  bool IsCulled(AxisAlignedBox box, std::shared_ptr<std::vector<glm::vec4>> planes) {
+    float dist;
 
-   bool IsCulled(AxisAlignedBox box, glm::vec4 * planes) {
-     float dist;
+    // If the max point is on the left side of the plane, cull
+    dist = DistToPlane(planes->at(LEFT).x, planes->at(LEFT).y, planes->at(LEFT).z, planes->at(LEFT).w, box.GetMax());
+    if (dist <= 0) {
+      return true;
+    }
 
-     // If the max point is on the left side of the plane, cull
-     dist = DistToPlane(planes[LEFT].x, planes[LEFT].y, planes[LEFT].z, planes[LEFT].w, box.GetMax());
-     if (dist <= 0) {
-       return true;
-     }
+    // If the min point is on the right side of the plane, cull
+    dist = DistToPlane(planes->at(RIGHT).x, planes->at(RIGHT).y, planes->at(RIGHT).z, planes->at(RIGHT).w, box.GetMin());
+    if (dist <= 0) {
+      return true;
+    }
 
-     // If the min point is on the right side of the plane, cull
-     dist = DistToPlane(planes[RIGHT].x, planes[RIGHT].y, planes[RIGHT].z, planes[RIGHT].w, box.GetMin());
-     if (dist <= 0) {
-       return true;
-     }
+    // If the min point is above the plane, cull
+    dist = DistToPlane(planes->at(TOP).x, planes->at(TOP).y, planes->at(TOP).z, planes->at(TOP).w, box.GetMin());
+    if (dist <= 0) {
+      return true;
+    }
 
-     // If the min point is above the plane, cull
-     dist = DistToPlane(planes[TOP].x, planes[TOP].y, planes[TOP].z, planes[TOP].w, box.GetMin());
-     if (dist <= 0) {
-       return true;
-     }
+    // If the max point is below the plane, cull
+    dist = DistToPlane(planes->at(BOTTOM).x, planes->at(BOTTOM).y, planes->at(BOTTOM).z, planes->at(BOTTOM).w, box.GetMax());
+    if (dist <= 0) {
+      return true;
+    }
 
-     // If the max point is below the plane, cull
-     dist = DistToPlane(planes[BOTTOM].x, planes[BOTTOM].y, planes[BOTTOM].z, planes[BOTTOM].w, box.GetMax());
-     if (dist <= 0) {
-       return true;
-     }
+    // If the max point is in front of the plane, cull
+    dist = DistToPlane(planes->at(NEAR).x, planes->at(NEAR).y, planes->at(NEAR).z, planes->at(NEAR).w, box.GetMax());
+    if (dist <= 0) {
+      return true;
+    }
 
-     // If the max point is in front of the plane, cull
-     dist = DistToPlane(planes[NEAR].x, planes[NEAR].y, planes[NEAR].z, planes[NEAR].w, box.GetMax());
-     if (dist <= 0) {
-       return true;
-     }
+    // If the min point is in behind the plane, cull
+    dist = DistToPlane(planes->at(FAR).x, planes->at(FAR).y, planes->at(FAR).z, planes->at(FAR).w, box.GetMax());
+    if (dist <= 0) {
+      return true;
+    }
 
-     // If the min point is in behind the plane, cull
-     dist = DistToPlane(planes[FAR].x, planes[FAR].y, planes[FAR].z, planes[FAR].w, box.GetMax());
-     if (dist <= 0) {
-       return true;
-     }
-
-     return false;
-   } 
+    return false;
+  } 
 }

--- a/src/game_renderer/ViewFrustumCulling.cpp
+++ b/src/game_renderer/ViewFrustumCulling.cpp
@@ -80,37 +80,37 @@ namespace ViewFrustumCulling {
     float dist;
 
     // If the max point is on the left side of the plane, cull
-    dist = DistToPlane(planes->at(LEFT).x, planes->at(LEFT).y, planes->at(LEFT).z, planes->at(LEFT).w, box.GetMax());
+    dist = DistToPlane(planes->at(VFC_LEFT).x, planes->at(VFC_LEFT).y, planes->at(VFC_LEFT).z, planes->at(VFC_LEFT).w, box.GetMax());
     if (dist <= 0) {
       return true;
     }
 
     // If the min point is on the right side of the plane, cull
-    dist = DistToPlane(planes->at(RIGHT).x, planes->at(RIGHT).y, planes->at(RIGHT).z, planes->at(RIGHT).w, box.GetMin());
+    dist = DistToPlane(planes->at(VFC_RIGHT).x, planes->at(VFC_RIGHT).y, planes->at(VFC_RIGHT).z, planes->at(VFC_RIGHT).w, box.GetMin());
     if (dist <= 0) {
       return true;
     }
 
     // If the min point is above the plane, cull
-    dist = DistToPlane(planes->at(TOP).x, planes->at(TOP).y, planes->at(TOP).z, planes->at(TOP).w, box.GetMin());
+    dist = DistToPlane(planes->at(VFC_TOP).x, planes->at(VFC_TOP).y, planes->at(VFC_TOP).z, planes->at(VFC_TOP).w, box.GetMin());
     if (dist <= 0) {
       return true;
     }
 
     // If the max point is below the plane, cull
-    dist = DistToPlane(planes->at(BOTTOM).x, planes->at(BOTTOM).y, planes->at(BOTTOM).z, planes->at(BOTTOM).w, box.GetMax());
+    dist = DistToPlane(planes->at(VFC_BOTTOM).x, planes->at(VFC_BOTTOM).y, planes->at(VFC_BOTTOM).z, planes->at(VFC_BOTTOM).w, box.GetMax());
     if (dist <= 0) {
       return true;
     }
 
     // If the max point is in front of the plane, cull
-    dist = DistToPlane(planes->at(NEAR).x, planes->at(NEAR).y, planes->at(NEAR).z, planes->at(NEAR).w, box.GetMax());
+    dist = DistToPlane(planes->at(VFC_NEAR).x, planes->at(VFC_NEAR).y, planes->at(VFC_NEAR).z, planes->at(VFC_NEAR).w, box.GetMax());
     if (dist <= 0) {
       return true;
     }
 
     // If the min point is in behind the plane, cull
-    dist = DistToPlane(planes->at(FAR).x, planes->at(FAR).y, planes->at(FAR).z, planes->at(FAR).w, box.GetMax());
+    dist = DistToPlane(planes->at(VFC_FAR).x, planes->at(VFC_FAR).y, planes->at(VFC_FAR).z, planes->at(VFC_FAR).w, box.GetMax());
     if (dist <= 0) {
       return true;
     }

--- a/src/game_renderer/ViewFrustumCulling.cpp
+++ b/src/game_renderer/ViewFrustumCulling.cpp
@@ -4,117 +4,131 @@
 
 namespace ViewFrustumCulling {
 
-  // Code from CPE-476 lab
-  std::shared_ptr<std::vector<glm::vec4>> GetViewFrustumPlanes(glm::mat4 P, glm::mat4 V) {
-    glm::vec4 Left, Right, Bottom, Top, Near, Far;
-    std::shared_ptr<std::vector<glm::vec4>> planes =
+// Code from CPE-476 lab
+std::shared_ptr<std::vector<glm::vec4>> GetViewFrustumPlanes(glm::mat4 P,
+                                                             glm::mat4 V) {
+  glm::vec4 Left, Right, Bottom, Top, Near, Far;
+  std::shared_ptr<std::vector<glm::vec4>> planes =
       std::make_shared<std::vector<glm::vec4>>();
-    planes->reserve(6);
-    glm::vec3 normal;
-    float normal_length;
+  planes->reserve(6);
+  glm::vec3 normal;
+  float normal_length;
 
-    glm::mat4 comp = P * V;
-     
-    Left.x = comp[0][3] + comp[0][0];
-    Left.y = comp[1][3] + comp[1][0];
-    Left.z = comp[2][3] + comp[2][0];
-    Left.w = comp[3][3] + comp[3][0];
-    normal = glm::vec3(Left.x, Left.y, Left.z);
-    normal_length = glm::length(normal);
-    planes->push_back(Left/normal_length);
-    Left = Left/normal_length;
-    
-    Right.x = comp[0][3] - comp[0][0];
-    Right.y = comp[1][3] - comp[1][0];
-    Right.z = comp[2][3] - comp[2][0];
-    Right.w = comp[3][3] - comp[3][0];
-    normal = glm::vec3(Right.x, Right.y, Right.z);
-    normal_length = glm::length(normal);
-    planes->push_back(Right/normal_length);
-    Right = Right/normal_length;
+  glm::mat4 comp = P * V;
 
-    Bottom.x = comp[0][3] + comp[0][1];
-    Bottom.y = comp[1][3] + comp[1][1];
-    Bottom.z = comp[2][3] + comp[2][1];
-    Bottom.w = comp[3][3] + comp[3][1];
-    normal = glm::vec3(Bottom.x, Bottom.y, Bottom.z);
-    normal_length = glm::length(normal);
-    planes->push_back(Bottom/normal_length);
-    Bottom = Bottom/normal_length;
+  Left.x = comp[0][3] + comp[0][0];
+  Left.y = comp[1][3] + comp[1][0];
+  Left.z = comp[2][3] + comp[2][0];
+  Left.w = comp[3][3] + comp[3][0];
+  normal = glm::vec3(Left.x, Left.y, Left.z);
+  normal_length = glm::length(normal);
+  planes->push_back(Left / normal_length);
+  Left = Left / normal_length;
 
-    Top.x = comp[0][3] - comp[0][1];
-    Top.y = comp[1][3] - comp[1][1];
-    Top.z = comp[2][3] - comp[2][1];
-    Top.w = comp[3][3] - comp[3][1];
-    normal = glm::vec3(Top.x, Top.y, Top.z);
-    normal_length = glm::length(normal);
-    planes->push_back(Top/normal_length);
-    Top = Top/normal_length;
+  Right.x = comp[0][3] - comp[0][0];
+  Right.y = comp[1][3] - comp[1][0];
+  Right.z = comp[2][3] - comp[2][0];
+  Right.w = comp[3][3] - comp[3][0];
+  normal = glm::vec3(Right.x, Right.y, Right.z);
+  normal_length = glm::length(normal);
+  planes->push_back(Right / normal_length);
+  Right = Right / normal_length;
 
-    Near.x = comp[0][3] + comp[0][2];
-    Near.y = comp[1][3] + comp[1][2];
-    Near.z = comp[2][3] + comp[2][2];
-    Near.w = comp[3][3] + comp[3][2];
-    normal = glm::vec3(Near.x, Near.y, Near.z);
-    normal_length = glm::length(normal);
-    planes->push_back(Near/normal_length);
-    Near = Near/normal_length;
+  Bottom.x = comp[0][3] + comp[0][1];
+  Bottom.y = comp[1][3] + comp[1][1];
+  Bottom.z = comp[2][3] + comp[2][1];
+  Bottom.w = comp[3][3] + comp[3][1];
+  normal = glm::vec3(Bottom.x, Bottom.y, Bottom.z);
+  normal_length = glm::length(normal);
+  planes->push_back(Bottom / normal_length);
+  Bottom = Bottom / normal_length;
 
-    Far.x = comp[0][3] - comp[0][2];
-    Far.y = comp[1][3] - comp[1][2];
-    Far.z = comp[2][3] - comp[2][2];
-    Far.w = comp[3][3] - comp[3][2];
-    normal = glm::vec3(Far.x, Far.y, Far.z);
-    normal_length = glm::length(normal);
-    planes->push_back(Far/normal_length);
-    Far = Far/normal_length;
+  Top.x = comp[0][3] - comp[0][1];
+  Top.y = comp[1][3] - comp[1][1];
+  Top.z = comp[2][3] - comp[2][1];
+  Top.w = comp[3][3] - comp[3][1];
+  normal = glm::vec3(Top.x, Top.y, Top.z);
+  normal_length = glm::length(normal);
+  planes->push_back(Top / normal_length);
+  Top = Top / normal_length;
 
-    return planes;   
+  Near.x = comp[0][3] + comp[0][2];
+  Near.y = comp[1][3] + comp[1][2];
+  Near.z = comp[2][3] + comp[2][2];
+  Near.w = comp[3][3] + comp[3][2];
+  normal = glm::vec3(Near.x, Near.y, Near.z);
+  normal_length = glm::length(normal);
+  planes->push_back(Near / normal_length);
+  Near = Near / normal_length;
+
+  Far.x = comp[0][3] - comp[0][2];
+  Far.y = comp[1][3] - comp[1][2];
+  Far.z = comp[2][3] - comp[2][2];
+  Far.w = comp[3][3] - comp[3][2];
+  normal = glm::vec3(Far.x, Far.y, Far.z);
+  normal_length = glm::length(normal);
+  planes->push_back(Far / normal_length);
+  Far = Far / normal_length;
+
+  return planes;
+}
+
+float DistToPlane(float A, float B, float C, float D, glm::vec3 point) {
+  return (A * point.x + B * point.y + C * point.z + D);
+}
+
+bool IsCulled(AxisAlignedBox box,
+              std::shared_ptr<std::vector<glm::vec4>> planes) {
+  float dist;
+
+  // If the max point is on the left side of the plane, cull
+  dist =
+      DistToPlane(planes->at(VFC_LEFT).x, planes->at(VFC_LEFT).y,
+                  planes->at(VFC_LEFT).z, planes->at(VFC_LEFT).w, box.GetMax());
+  if (dist <= 0) {
+    return true;
   }
 
-  float DistToPlane(float A, float B, float C, float D, glm::vec3 point) {
-    return (A * point.x + B * point.y + C * point.z + D);
+  // If the min point is on the right side of the plane, cull
+  dist = DistToPlane(planes->at(VFC_RIGHT).x, planes->at(VFC_RIGHT).y,
+                     planes->at(VFC_RIGHT).z, planes->at(VFC_RIGHT).w,
+                     box.GetMin());
+  if (dist <= 0) {
+    return true;
   }
 
-  bool IsCulled(AxisAlignedBox box, std::shared_ptr<std::vector<glm::vec4>> planes) {
-    float dist;
+  // If the min point is above the plane, cull
+  dist =
+      DistToPlane(planes->at(VFC_TOP).x, planes->at(VFC_TOP).y,
+                  planes->at(VFC_TOP).z, planes->at(VFC_TOP).w, box.GetMin());
+  if (dist <= 0) {
+    return true;
+  }
 
-    // If the max point is on the left side of the plane, cull
-    dist = DistToPlane(planes->at(VFC_LEFT).x, planes->at(VFC_LEFT).y, planes->at(VFC_LEFT).z, planes->at(VFC_LEFT).w, box.GetMax());
-    if (dist <= 0) {
-      return true;
-    }
+  // If the max point is below the plane, cull
+  dist = DistToPlane(planes->at(VFC_BOTTOM).x, planes->at(VFC_BOTTOM).y,
+                     planes->at(VFC_BOTTOM).z, planes->at(VFC_BOTTOM).w,
+                     box.GetMax());
+  if (dist <= 0) {
+    return true;
+  }
 
-    // If the min point is on the right side of the plane, cull
-    dist = DistToPlane(planes->at(VFC_RIGHT).x, planes->at(VFC_RIGHT).y, planes->at(VFC_RIGHT).z, planes->at(VFC_RIGHT).w, box.GetMin());
-    if (dist <= 0) {
-      return true;
-    }
+  // If the max point is in front of the plane, cull
+  dist =
+      DistToPlane(planes->at(VFC_NEAR).x, planes->at(VFC_NEAR).y,
+                  planes->at(VFC_NEAR).z, planes->at(VFC_NEAR).w, box.GetMax());
+  if (dist <= 0) {
+    return true;
+  }
 
-    // If the min point is above the plane, cull
-    dist = DistToPlane(planes->at(VFC_TOP).x, planes->at(VFC_TOP).y, planes->at(VFC_TOP).z, planes->at(VFC_TOP).w, box.GetMin());
-    if (dist <= 0) {
-      return true;
-    }
+  // If the min point is in behind the plane, cull
+  dist =
+      DistToPlane(planes->at(VFC_FAR).x, planes->at(VFC_FAR).y,
+                  planes->at(VFC_FAR).z, planes->at(VFC_FAR).w, box.GetMax());
+  if (dist <= 0) {
+    return true;
+  }
 
-    // If the max point is below the plane, cull
-    dist = DistToPlane(planes->at(VFC_BOTTOM).x, planes->at(VFC_BOTTOM).y, planes->at(VFC_BOTTOM).z, planes->at(VFC_BOTTOM).w, box.GetMax());
-    if (dist <= 0) {
-      return true;
-    }
-
-    // If the max point is in front of the plane, cull
-    dist = DistToPlane(planes->at(VFC_NEAR).x, planes->at(VFC_NEAR).y, planes->at(VFC_NEAR).z, planes->at(VFC_NEAR).w, box.GetMax());
-    if (dist <= 0) {
-      return true;
-    }
-
-    // If the min point is in behind the plane, cull
-    dist = DistToPlane(planes->at(VFC_FAR).x, planes->at(VFC_FAR).y, planes->at(VFC_FAR).z, planes->at(VFC_FAR).w, box.GetMax());
-    if (dist <= 0) {
-      return true;
-    }
-
-    return false;
-  } 
+  return false;
+}
 }

--- a/src/game_renderer/ViewFrustumCulling.cpp
+++ b/src/game_renderer/ViewFrustumCulling.cpp
@@ -1,0 +1,116 @@
+#include "ViewFrustumCulling.h"
+
+namespace ViewFrustumCulling {
+
+   // Code from CPE-476 lab
+   glm::vec4 * GetViewFrustumPlanes(glm::mat4 P, glm::mat4 V) {
+     glm::vec4 Left, Right, Bottom, Top, Near, Far;
+     glm::vec4 *planes = (glm::vec4 *)malloc(sizeof(glm::vec4) * 6);
+     glm::vec3 normal;
+     float normal_length;
+    
+     glm::mat4 comp = P * V;
+     
+     Left.x = comp[0][3] + comp[0][0];
+     Left.y = comp[1][3] + comp[1][0];
+     Left.z = comp[2][3] + comp[2][0];
+     Left.w = comp[3][3] + comp[3][0];
+     normal = glm::vec3(Left.x, Left.y, Left.z);
+     normal_length = glm::length(normal);
+     planes[0] = Left/normal_length;
+     Left = Left/normal_length;
+
+     Right.x = comp[0][3] - comp[0][0];
+     Right.y = comp[1][3] - comp[1][0];
+     Right.z = comp[2][3] - comp[2][0];
+     Right.w = comp[3][3] - comp[3][0];
+     normal = glm::vec3(Right.x, Right.y, Right.z);
+     normal_length = glm::length(normal);
+     planes[1] = Right/normal_length;
+     Right = Right/normal_length;
+
+     Bottom.x = comp[0][3] + comp[0][1];
+     Bottom.y = comp[1][3] + comp[1][1];
+     Bottom.z = comp[2][3] + comp[2][1];
+     Bottom.w = comp[3][3] + comp[3][1];
+     normal = glm::vec3(Bottom.x, Bottom.y, Bottom.z);
+     normal_length = glm::length(normal);
+     planes[2] = Bottom/normal_length;
+     Bottom = Bottom/normal_length;
+
+     Top.x = comp[0][3] - comp[0][1];
+     Top.y = comp[1][3] - comp[1][1];
+     Top.z = comp[2][3] - comp[2][1];
+     Top.w = comp[3][3] - comp[3][1];
+     normal = glm::vec3(Top.x, Top.y, Top.z);
+     normal_length = glm::length(normal);
+     planes[3] = Top/normal_length;
+     Top = Top/normal_length;
+
+     Near.x = comp[0][3] + comp[0][2];
+     Near.y = comp[1][3] + comp[1][2];
+     Near.z = comp[2][3] + comp[2][2];
+     Near.w = comp[3][3] + comp[3][2];
+     normal = glm::vec3(Near.x, Near.y, Near.z);
+     normal_length = glm::length(normal);
+     planes[4] = Near/normal_length;
+     Near = Near/normal_length;
+
+     Far.x = comp[0][3] - comp[0][2];
+     Far.y = comp[1][3] - comp[1][2];
+     Far.z = comp[2][3] - comp[2][2];
+     Far.w = comp[3][3] - comp[3][2];
+     normal = glm::vec3(Far.x, Far.y, Far.z);
+     normal_length = glm::length(normal);
+     planes[5] = Far/normal_length;
+     Far = Far/normal_length;
+
+     return planes;
+   }
+
+   float DistToPlane(float A, float B, float C, float D, glm::vec3 point) {
+     return (A * point.x + B * point.y + C * point.z + D);
+   }
+
+   bool IsCulled(AxisAlignedBox box, glm::vec4 * planes) {
+     float dist;
+
+     // If the max point is on the left side of the plane, cull
+     dist = DistToPlane(planes[LEFT].x, planes[LEFT].y, planes[LEFT].z, planes[LEFT].w, box.GetMax());
+     if (dist <= 0) {
+       return true;
+     }
+
+     // If the min point is on the right side of the plane, cull
+     dist = DistToPlane(planes[RIGHT].x, planes[RIGHT].y, planes[RIGHT].z, planes[RIGHT].w, box.GetMin());
+     if (dist <= 0) {
+       return true;
+     }
+
+     // If the min point is above the plane, cull
+     dist = DistToPlane(planes[TOP].x, planes[TOP].y, planes[TOP].z, planes[TOP].w, box.GetMin());
+     if (dist <= 0) {
+       return true;
+     }
+
+     // If the max point is below the plane, cull
+     dist = DistToPlane(planes[BOTTOM].x, planes[BOTTOM].y, planes[BOTTOM].z, planes[BOTTOM].w, box.GetMax());
+     if (dist <= 0) {
+       return true;
+     }
+
+     // If the max point is in front of the plane, cull
+     dist = DistToPlane(planes[NEAR].x, planes[NEAR].y, planes[NEAR].z, planes[NEAR].w, box.GetMax());
+     if (dist <= 0) {
+       return true;
+     }
+
+     // If the min point is in behind the plane, cull
+     dist = DistToPlane(planes[FAR].x, planes[FAR].y, planes[FAR].z, planes[FAR].w, box.GetMax());
+     if (dist <= 0) {
+       return true;
+     }
+
+     return false;
+   } 
+}

--- a/src/game_renderer/ViewFrustumCulling.h
+++ b/src/game_renderer/ViewFrustumCulling.h
@@ -2,12 +2,12 @@
 #ifndef __VIEW_FRUST_CULLING__
 #define __VIEW_FRUST_CULLING__
 
-#define LEFT 0
-#define RIGHT 1
-#define BOTTOM 2
-#define TOP 3
-#define NEAR 4
-#define FAR 5
+#define VFC_LEFT 0
+#define VFC_RIGHT 1
+#define VFC_BOTTOM 2
+#define VFC_TOP 3
+#define VFC_NEAR 4
+#define VFC_FAR 5
 
 #include <glm/gtc/type_ptr.hpp>
 #include "game_state/AxisAlignedBox.h"

--- a/src/game_renderer/ViewFrustumCulling.h
+++ b/src/game_renderer/ViewFrustumCulling.h
@@ -13,8 +13,8 @@
 #include "game_state/AxisAlignedBox.h"
 
 namespace ViewFrustumCulling {
-    glm::vec4 * GetViewFrustumPlanes(glm::mat4 P, glm::mat4 V);
+    std::shared_ptr<std::vector<glm::vec4>> GetViewFrustumPlanes(glm::mat4 P, glm::mat4 V);
     float DistToPlane(float A, float B, float C, float D, glm::vec3 point);
-    bool IsCulled(AxisAlignedBox box, glm::vec4 * planes); 
+    bool IsCulled(AxisAlignedBox box, std::shared_ptr<std::vector<glm::vec4>> planes); 
 }
 #endif

--- a/src/game_renderer/ViewFrustumCulling.h
+++ b/src/game_renderer/ViewFrustumCulling.h
@@ -13,8 +13,10 @@
 #include "game_state/AxisAlignedBox.h"
 
 namespace ViewFrustumCulling {
-    std::shared_ptr<std::vector<glm::vec4>> GetViewFrustumPlanes(glm::mat4 P, glm::mat4 V);
-    float DistToPlane(float A, float B, float C, float D, glm::vec3 point);
-    bool IsCulled(AxisAlignedBox box, std::shared_ptr<std::vector<glm::vec4>> planes); 
+std::shared_ptr<std::vector<glm::vec4>> GetViewFrustumPlanes(glm::mat4 P,
+                                                             glm::mat4 V);
+float DistToPlane(float A, float B, float C, float D, glm::vec3 point);
+bool IsCulled(AxisAlignedBox box,
+              std::shared_ptr<std::vector<glm::vec4>> planes);
 }
 #endif

--- a/src/game_renderer/ViewFrustumCulling.h
+++ b/src/game_renderer/ViewFrustumCulling.h
@@ -1,0 +1,20 @@
+// Alex Ottoboni
+#ifndef __VIEW_FRUST_CULLING__
+#define __VIEW_FRUST_CULLING__
+
+#define LEFT 0
+#define RIGHT 1
+#define BOTTOM 2
+#define TOP 3
+#define NEAR 4
+#define FAR 5
+
+#include <glm/gtc/type_ptr.hpp>
+#include "game_state/AxisAlignedBox.h"
+
+namespace ViewFrustumCulling {
+    glm::vec4 * GetViewFrustumPlanes(glm::mat4 P, glm::mat4 V);
+    float DistToPlane(float A, float B, float C, float D, glm::vec3 point);
+    bool IsCulled(AxisAlignedBox box, glm::vec4 * planes); 
+}
+#endif


### PR DESCRIPTION
This culls platforms that are no longer in view, but can easily be extended to other things in the level. It is a little different from in lab since we are using bounding boxes instead of spheres. 

As far as I can tell its working based on the fact when I put print statements it says that platforms are not being drawn but I can still see everything that should be seen in the camera view. 

#50 