### PR TITLE
Textures Loaded from JSON like Shaders

### DIFF
--- a/assets/shaders/moving_plat.json
+++ b/assets/shaders/moving_plat.json
@@ -1,14 +1,16 @@
 {
   "attributes": [
     "vertPos",
-    "vertNor"
+    "vertNor",
+    "vertTex"
   ],
   "frag": "moving_platform_frag.glsl",
   "name": "moving_platform_prog",
   "uniforms": [
     "P",
     "V",
-    "MV"
+    "MV",
+    "Texture0"
   ],
   "vert": "moving_platform_vert.glsl"
 }

--- a/assets/shaders/platform.json
+++ b/assets/shaders/platform.json
@@ -1,14 +1,16 @@
 {
   "attributes": [
     "vertPos",
-    "vertNor"
+    "vertNor",
+    "vertTex"
   ],
   "frag": "platform_frag.glsl",
   "name": "platform_prog",
   "uniforms": [
     "P",
     "V",
-    "MV"
+    "MV",
+    "Texture0"
   ],
   "vert": "platform_vert.glsl"
 }

--- a/assets/shaders/player.json
+++ b/assets/shaders/player.json
@@ -9,7 +9,8 @@
   "uniforms": [
     "P",
     "V",
-    "MV"
+    "MV",
+    "Texture0"
   ],
   "vert": "player_vert.glsl"
 }

--- a/assets/textures/blacktex.json
+++ b/assets/textures/blacktex.json
@@ -1,0 +1,7 @@
+{
+  "filename": "blacktex.jpg", 
+  "name": "blacktex", 
+  "unit": 0, 
+  "wrap_mode_x": 10497, 
+  "wrap_mode_y": 10497
+}

--- a/assets/textures/cloud.json
+++ b/assets/textures/cloud.json
@@ -1,0 +1,7 @@
+{
+  "filename": "cloud.bmp", 
+  "name": "cloud", 
+  "unit": 0, 
+  "wrap_mode_x": 10497, 
+  "wrap_mode_y": 10497
+}

--- a/assets/textures/crate.json
+++ b/assets/textures/crate.json
@@ -1,0 +1,7 @@
+{
+  "filename": "crate.bmp", 
+  "name": "crate", 
+  "unit": 0, 
+  "wrap_mode_x": 10497, 
+  "wrap_mode_y": 10497
+}

--- a/assets/textures/gen_textures.sh
+++ b/assets/textures/gen_textures.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+rm *.json
+python ../../utils/TextureJSONGen.py *.jpg
+python ../../utils/TextureJSONGen.py *.bmp
+python ../../utils/TextureJSONGen.py *.png

--- a/assets/textures/grass.json
+++ b/assets/textures/grass.json
@@ -1,0 +1,7 @@
+{
+  "filename": "grass.jpg", 
+  "name": "grass", 
+  "unit": 0, 
+  "wrap_mode_x": 10497, 
+  "wrap_mode_y": 10497
+}

--- a/assets/textures/lightgrey.json
+++ b/assets/textures/lightgrey.json
@@ -1,0 +1,7 @@
+{
+  "filename": "lightgrey.png", 
+  "name": "lightgrey", 
+  "unit": 0, 
+  "wrap_mode_x": 10497, 
+  "wrap_mode_y": 10497
+}

--- a/assets/textures/rainbow.json
+++ b/assets/textures/rainbow.json
@@ -1,0 +1,7 @@
+{
+  "filename": "rainbow.png", 
+  "name": "rainbow", 
+  "unit": 0, 
+  "wrap_mode_x": 10497, 
+  "wrap_mode_y": 10497
+}

--- a/assets/textures/rainbowglass.json
+++ b/assets/textures/rainbowglass.json
@@ -1,0 +1,7 @@
+{
+  "filename": "rainbowglass.jpg", 
+  "name": "rainbowglass", 
+  "unit": 0, 
+  "wrap_mode_x": 10497, 
+  "wrap_mode_y": 10497
+}

--- a/assets/textures/skyblue.json
+++ b/assets/textures/skyblue.json
@@ -1,0 +1,7 @@
+{
+  "filename": "skyblue.jpg", 
+  "name": "skyblue", 
+  "unit": 0, 
+  "wrap_mode_x": 10497, 
+  "wrap_mode_y": 10497
+}

--- a/assets/textures/world.json
+++ b/assets/textures/world.json
@@ -1,0 +1,7 @@
+{
+  "filename": "world.jpg", 
+  "name": "world", 
+  "unit": 0, 
+  "wrap_mode_x": 10497, 
+  "wrap_mode_y": 10497
+}

--- a/src/game_renderer/GameRenderer.h
+++ b/src/game_renderer/GameRenderer.h
@@ -32,14 +32,13 @@ class GameRenderer {
   void ImGuiRender(std::shared_ptr<GameState> game_state);
 
   std::unordered_map<std::string, std::shared_ptr<Program>> programs;
+  std::unordered_map<std::string, std::shared_ptr<Texture>> textures;
   std::shared_ptr<Program> ProgramFromJSON(std::string filepath);
+  std::shared_ptr<Texture> TextureFromJSON(std::string filepath);
   static std::shared_ptr<std::unordered_set<std::shared_ptr<GameObject>>>
   GetObjectsInView(std::shared_ptr<std::vector<glm::vec4>> vfplane,
                    std::shared_ptr<Octree> tree);
   std::vector<glm::vec3> color_vec;
-  std::shared_ptr<Texture> texture0;
-  std::shared_ptr<Texture> texture1;
-  std::shared_ptr<Texture> texture2;
 };
 
 #endif

--- a/src/game_renderer/Texture.cpp
+++ b/src/game_renderer/Texture.cpp
@@ -79,3 +79,7 @@ void Texture::unbind()
 	glActiveTexture(GL_TEXTURE0 + unit);
 	glBindTexture(GL_TEXTURE_2D, 0);
 }
+
+std::string Texture::getName() {
+  return name;
+}

--- a/src/game_renderer/Texture.h
+++ b/src/game_renderer/Texture.h
@@ -10,22 +10,25 @@
 class Texture
 {
 public:
-	Texture();
-	virtual ~Texture();
-	void setFilename(const std::string &f) { filename = f; }
-	void init();
-	void setUnit(GLint u) { unit = u; }
-	GLint getUnit() const { return unit; }
-	void bind(GLint handle);
-	void unbind();
-	void setWrapModes(GLint wrapS, GLint wrapT); // Must be called after init()
+  Texture();
+  virtual ~Texture();
+  void setFilename(const std::string &f) { filename = f; }
+  void setName(const std::string &f) {name = f; }
+  void init();
+  void setUnit(GLint u) { unit = u; }
+  GLint getUnit() const { return unit; }
+  void bind(GLint handle);
+  void unbind();
+  void setWrapModes(GLint wrapS, GLint wrapT); // Must be called after init()
+  std::string getName();
 	
 private:
-	std::string filename;
-	int width;
-	int height;
-	GLuint tid;
-	GLint unit;
+  std::string filename;
+  int width;
+  int height;
+  GLuint tid;
+  GLint unit;
+  std::string name;
 	
 };
 

--- a/utils/TextureJSONGen.py
+++ b/utils/TextureJSONGen.py
@@ -1,0 +1,17 @@
+import json
+import sys
+
+def gen_texture(filename):
+  tex_def = {}
+  name = filename.split("/")[-1].split(".")[0]
+  tex_def["name"] = name
+  tex_def["filename"] = filename
+  tex_def["unit"] = 0
+  tex_def["wrap_mode_x"] = 10497 # GL_REPEAT
+  tex_def["wrap_mode_y"] = 10497 # GL_REPEAT
+  output_file = open(name + ".json", 'w')
+  output_file.write(json.dumps(tex_def, sort_keys=True, indent=2))
+  
+if __name__ == "__main__":
+  for item in sys.argv[1:]:
+    gen_texture(item)


### PR DESCRIPTION
Each texture file has a corresponding JSON file that the game renderer uses to create all the textures at the start of the game. 

To automatically generate default json files for all the images in the textures directory if you're on OS X run: gen_textures.sh. If you're on Windows just run the python script in utils, I dunno how windows scripting works...

They are accessed just like shaders ie:
`std::shared_ptr<Texture> temp_texture = textures[NAME_WITHOUT_EXTENSION]`

#94 