### PR TITLE
Added support for object rotation

### DIFF
--- a/src/game_state/AxisAlignedBox.cpp
+++ b/src/game_state/AxisAlignedBox.cpp
@@ -13,21 +13,29 @@ bool AxisAlignedBox::IsColliding(const AxisAlignedBox& one,
          one.min.z <= two.max.z && one.max.z >= two.min.z;
 }
 
-MatrixStack AxisAlignedBox::GetTransform(glm::vec3 position, glm::vec3 scale) {
+MatrixStack AxisAlignedBox::GetTransform(glm::vec3 position, glm::vec3 scale,
+                                         float angle, glm::vec3 axis) {
   // TODO(jarhar): make this more efficient by caching calculated matrix
   MatrixStack transform;
   transform.pushMatrix();
   transform.loadIdentity();
   transform.translate(position);
-  // TODO(jarhar): rotate
+  transform.rotate(angle, axis);
   transform.scale(scale);
   return transform;
 }
 
 AxisAlignedBox::AxisAlignedBox(std::shared_ptr<Shape> model,
+                               glm::vec3 scale, glm::vec3 position)
+   : AxisAlignedBox(model, scale, position, 0.0f, glm::vec3(0,1,0)) {}
+
+AxisAlignedBox::AxisAlignedBox(std::shared_ptr<Shape> model,
                                glm::vec3 scale,
-                               glm::vec3 position)
-    : AxisAlignedBox(model, GetTransform(position, scale).topMatrix()) {}
+                               glm::vec3 position,
+                               float angle,
+                               glm::vec3 axis)
+    : AxisAlignedBox(model, GetTransform(position, scale,
+                                         angle, axis).topMatrix()) {}
 
 AxisAlignedBox::AxisAlignedBox(glm::vec3 min, glm::vec3 max)
     : min(min), max(max) {}

--- a/src/game_state/AxisAlignedBox.h
+++ b/src/game_state/AxisAlignedBox.h
@@ -14,13 +14,19 @@
 class AxisAlignedBox {
  public:
   static bool IsColliding(const AxisAlignedBox& one, const AxisAlignedBox& two);
-  static MatrixStack GetTransform(glm::vec3 position, glm::vec3 scale);
+  static MatrixStack GetTransform(glm::vec3 position, glm::vec3 scale,
+                                  float angle, glm::vec3 axis);
 
   AxisAlignedBox(std::shared_ptr<Shape> model, glm::mat4 transform);
   AxisAlignedBox(glm::vec3 min, glm::vec3 max);
   AxisAlignedBox(std::shared_ptr<Shape> model,
                  glm::vec3 scale,
                  glm::vec3 position);
+  AxisAlignedBox(std::shared_ptr<Shape> model,
+                 glm::vec3 scale,
+                 glm::vec3 position,
+                 float angle,
+                 glm::vec3 axis);
   ~AxisAlignedBox();
 
   AxisAlignedBox merge(AxisAlignedBox other);

--- a/src/game_state/GameObject.cpp
+++ b/src/game_state/GameObject.cpp
@@ -7,7 +7,12 @@
 #include "Logging.h"
 
 // TODO(jarhar): make this constructor require all fields
-GameObject::GameObject(std::shared_ptr<Shape> model) : model(model) {}
+GameObject::GameObject(std::shared_ptr<Shape> model) : model(model) {
+  this->position = glm::vec3(0.0f, 0.0f, 0.0f);
+  this->scale = glm::vec3(1.0f, 1.0f, 1.0f);
+  this->rotation_angle = 0.0f;
+  this->rotation_axis = glm::vec3(0.0f, 1.0f, 0.0f);
+}
 
 GameObject::~GameObject() {}
 
@@ -32,7 +37,8 @@ glm::vec3 GameObject::GetScale() const {
 }
 
 MatrixStack GameObject::GetTransform() {
-  return AxisAlignedBox::GetTransform(GetPosition(), GetScale());
+  return AxisAlignedBox::GetTransform(GetPosition(), GetScale(),
+                                      GetRotationAngle(), GetRotationAxis());
 }
 
 AxisAlignedBox GameObject::GetBoundingBox() {


### PR DESCRIPTION
Collision can be messed up with platforms that are rotated, since things are no longer axis aligned