### PR TITLE
Overhauled controls

### DIFF
--- a/deps/imgui-glew/imgui_impl_glfw_gl3.cpp
+++ b/deps/imgui-glew/imgui_impl_glfw_gl3.cpp
@@ -395,7 +395,7 @@ void ImGui_ImplGlfwGL3_NewFrame()
     g_MouseWheel = 0.0f;
 
     // Hide OS mouse cursor if ImGui is drawing it
-    glfwSetInputMode(g_Window, GLFW_CURSOR, io.MouseDrawCursor ? GLFW_CURSOR_HIDDEN : GLFW_CURSOR_NORMAL);
+    //glfwSetInputMode(g_Window, GLFW_CURSOR, io.MouseDrawCursor ? GLFW_CURSOR_HIDDEN : GLFW_CURSOR_NORMAL);
 
     // Start the frame
     ImGui::NewFrame();

--- a/src/LevelEditor.cpp
+++ b/src/LevelEditor.cpp
@@ -19,8 +19,6 @@
 #include "Platform.h"
 #include "LevelEditorUpdater.h"
 #include "LevelEditorState.h"
-//#include "AllTheThings.h"
-//#include "*.h"
 
 #define MUSIC "music/2.wav"
 
@@ -40,7 +38,6 @@ int main(int argc, char** argv) {
   while (!glfwWindowShouldClose(window)) {
     switch (program_mode) {
       case LevelProgramMode::MENU_SCREEN: {
-        InputBindings::StoreKeypresses();
         program_mode = menu_renderer.Render(window, menu_state);
         break;
       }
@@ -113,6 +110,7 @@ int main(int argc, char** argv) {
         game_state->SetLevelEditorState(std::make_shared<LevelEditorState>());
         game_state->GetLevelEditorState()->SetLevelPath(
             menu_state->GetLevelPath());
+        game_state->SetPlayingState(GameState::PlayingState::PAUSED);
 
         program_mode = LevelProgramMode::EDIT_LEVEL;
         break;

--- a/src/RhythmRunner.cpp
+++ b/src/RhythmRunner.cpp
@@ -65,8 +65,6 @@ int main(int argc, char** argv) {
   program_mode = MainProgramMode::MENU_SCREEN;
 
   while (!glfwWindowShouldClose(window)) {
-    bool keypress_override = false;
-
     switch (program_mode) {
       case MainProgramMode::CREATE_NEW_GAME: {
         LevelGenerator* level_generator;
@@ -97,8 +95,9 @@ int main(int argc, char** argv) {
       }
       case MainProgramMode::RESET_GAME:
         game_updater.Reset(game_state);
-
-      // continue to GAME_SCREEN
+        // lock cursor when starting game
+        InputBindings::SetCursorMode(InputBindings::CursorMode::LOCKED);
+        // continue to GAME_SCREEN
       case MainProgramMode::GAME_SCREEN: {
         switch (game_state->GetPlayingState()) {
           case GameState::PlayingState::FAILURE:
@@ -116,8 +115,6 @@ int main(int argc, char** argv) {
             // Update().
             //  What if the music starts/stops during one of multiple Update()s?
             while (game_state->GetElapsedTicks() < target_tick_count) {
-              keypress_override = true;
-              InputBindings::StoreKeypresses();
               game_updater.Update(game_state);
             }
             break;
@@ -138,11 +135,6 @@ int main(int argc, char** argv) {
     }
 
     PrintStatus();
-
-    if (!keypress_override) {
-      InputBindings::StoreKeypresses();
-    }
-    keypress_override = false;
   }
 
   RendererSetup::Close(window);

--- a/src/game_renderer/InputBindings.h
+++ b/src/game_renderer/InputBindings.h
@@ -11,10 +11,14 @@ class InputBindings {
  public:
   static void Bind(GLFWwindow* window);
 
-  // These are used to tell if the player "pressed" a button based on whether or
-  // not they were already pressing it during the last frame
-  static void StoreKeypresses();
-  static bool KeyNewlyPressed(int key);
+  static bool KeyDown(int key);
+  static bool KeyPressed(int key);
+  static void ClearKeyPresses();
+
+  enum CursorMode { FREE = 1, LOCKED = 2 };
+  static void SetCursorMode(CursorMode cursor_mode);
+  static CursorMode GetCursorMode();
+  static std::pair<float, float> GetCursorDiff();
 
  private:
   InputBindings();

--- a/src/game_renderer/LevelEditorMenuRenderer.cpp
+++ b/src/game_renderer/LevelEditorMenuRenderer.cpp
@@ -20,9 +20,9 @@ LevelProgramMode LevelEditorMenuRenderer::Render(
   ImGui_ImplGlfwGL3_NewFrame();
 
   // Create a centered window that takes up 50% of the screen
-  RendererSetup::ImGuiCenterWindow(0.5);
+  RendererSetup::ImGuiCenterWindow(0.5, RendererSetup::DYNAMIC);
   ImGui::Begin("Rhythm Runner Level Editor", NULL,
-               RendererSetup::TITLE_WINDOW_FLAGS);
+               RendererSetup::DYNAMIC_WINDOW_FLAGS);
 
   static char music_path_buffer[TEXT_FIELD_LENGTH];
   static char level_path_buffer[TEXT_FIELD_LENGTH];
@@ -43,15 +43,15 @@ LevelProgramMode LevelEditorMenuRenderer::Render(
   }
 
   if (ImGui::Button("Generate Level From Music [ENTER]") ||
-      InputBindings::KeyNewlyPressed(GLFW_KEY_ENTER)) {
+      InputBindings::KeyPressed(GLFW_KEY_ENTER)) {
     program_mode = LevelProgramMode::GENERATE_LEVEL;
   }
   if (ImGui::Button("Level Editor [TAB]") ||
-      InputBindings::KeyNewlyPressed(GLFW_KEY_TAB)) {
+      InputBindings::KeyPressed(GLFW_KEY_TAB)) {
     program_mode = LevelProgramMode::START_EDIT_LEVEL;
   }
   if (ImGui::Button("Exit [ESCAPE]") ||
-      InputBindings::KeyNewlyPressed(GLFW_KEY_ESCAPE)) {
+      InputBindings::KeyPressed(GLFW_KEY_ESCAPE)) {
     program_mode = LevelProgramMode::EXIT;
   }
 

--- a/src/game_renderer/MenuRenderer.cpp
+++ b/src/game_renderer/MenuRenderer.cpp
@@ -21,8 +21,8 @@ MainProgramMode MenuRenderer::Render(GLFWwindow* window,
   ImGui_ImplGlfwGL3_NewFrame();
 
   // Create a centered window that takes up 50% of the screen
-  RendererSetup::ImGuiCenterWindow(0.5);
-  ImGui::Begin("Rhythm Runner", NULL, RendererSetup::TITLE_WINDOW_FLAGS);
+  RendererSetup::ImGuiCenterWindow(0.5, RendererSetup::DYNAMIC);
+  ImGui::Begin("Rhythm Runner", NULL, RendererSetup::DYNAMIC_WINDOW_FLAGS);
 
   static char music_path_buffer[TEXT_FIELD_LENGTH];
   static char level_path_buffer[TEXT_FIELD_LENGTH];
@@ -45,14 +45,14 @@ MainProgramMode MenuRenderer::Render(GLFWwindow* window,
   }
 
   if (ImGui::Button("Start [ENTER]") ||
-      InputBindings::KeyNewlyPressed(GLFW_KEY_ENTER)) {
+      InputBindings::KeyPressed(GLFW_KEY_ENTER)) {
     // TODO(jarhar): validate music filepath here
     program_mode = MainProgramMode::CREATE_NEW_GAME;
   }
 
   if (ImGui::Button("Exit [ESCAPE][Q]") ||
-      InputBindings::KeyNewlyPressed(GLFW_KEY_ESCAPE) ||
-      InputBindings::KeyNewlyPressed(GLFW_KEY_Q)) {
+      InputBindings::KeyPressed(GLFW_KEY_ESCAPE) ||
+      InputBindings::KeyPressed(GLFW_KEY_Q)) {
     program_mode = MainProgramMode::EXIT;
   }
 

--- a/src/game_renderer/RendererSetup.cpp
+++ b/src/game_renderer/RendererSetup.cpp
@@ -33,7 +33,7 @@ GLFWwindow* RendererSetup::InitOpenGL() {
   window = glfwCreateWindow(mode->width, mode->height, TITLE, monitor, NULL);
 #endif
   glfwMakeContextCurrent(window);
-  glfwSetInputMode(window, GLFW_CURSOR, GLFW_CURSOR_DISABLED);
+  glfwSetInputMode(window, GLFW_CURSOR, GLFW_CURSOR_NORMAL);
   glewExperimental = true;
   if (glewInit() != GLEW_OK) {
     std::cerr << "Failed to initialize GLEW" << std::endl;
@@ -77,36 +77,53 @@ void RendererSetup::Close(GLFWwindow* window) {
   glfwTerminate();
 }
 
-void RendererSetup::ImGuiCenterWindow(double ratio) {
+void RendererSetup::ImGuiCenterWindow(double ratio, bool dynamic) {
   ImGuiIO& imgui_io = ImGui::GetIO();
   int window_width = imgui_io.DisplaySize.x * ratio;
   int window_height = imgui_io.DisplaySize.y * ratio;
-  ImGui::SetNextWindowSize(ImVec2(window_width, window_height),
-                           ImGuiSetCond_FirstUseEver);
+  ImGui::SetNextWindowSize(
+      ImVec2(window_width, window_height),
+      dynamic ? ImGuiSetCond_FirstUseEver : ImGuiSetCond_Always);
   ImGui::SetNextWindowPos(
       ImVec2(imgui_io.DisplaySize.x / 2 - window_width / 2,
              imgui_io.DisplaySize.y / 2 - window_height / 2),
-      ImGuiSetCond_FirstUseEver);
+      dynamic ? ImGuiSetCond_FirstUseEver : ImGuiSetCond_Always);
 }
 
-void RendererSetup::ImGuiTopRightCornerWindow(double ratio) {
+void RendererSetup::ImGuiTopRightCornerWindow(double ratio, bool dynamic) {
   ImGuiIO& imgui_io = ImGui::GetIO();
   int window_width = imgui_io.DisplaySize.x * ratio;
   int window_height = imgui_io.DisplaySize.y * ratio;
-  ImGui::SetNextWindowSize(ImVec2(window_width, window_height),
-                           ImGuiSetCond_FirstUseEver);
+  ImGui::SetNextWindowSize(
+      ImVec2(window_width, window_height),
+      dynamic ? ImGuiSetCond_FirstUseEver : ImGuiSetCond_Always);
   ImGui::SetNextWindowPos(
       ImVec2(imgui_io.DisplaySize.x - window_width - IMGUI_WINDOW_PADDING,
              IMGUI_WINDOW_PADDING),
-      ImGuiSetCond_FirstUseEver);
+      dynamic ? ImGuiSetCond_FirstUseEver : ImGuiSetCond_Always);
 }
 
-void RendererSetup::ImGuiTopLeftCornerWindow(double ratio) {
+void RendererSetup::ImGuiTopLeftCornerWindow(double ratio, bool dynamic) {
   ImGuiIO& imgui_io = ImGui::GetIO();
   int window_width = imgui_io.DisplaySize.x * ratio;
   int window_height = imgui_io.DisplaySize.y * ratio;
-  ImGui::SetNextWindowSize(ImVec2(window_width, window_height),
-                           ImGuiSetCond_FirstUseEver);
-  ImGui::SetNextWindowPos(ImVec2(IMGUI_WINDOW_PADDING, IMGUI_WINDOW_PADDING),
-                          ImGuiSetCond_FirstUseEver);
+  ImGui::SetNextWindowSize(
+      ImVec2(window_width, window_height),
+      dynamic ? ImGuiSetCond_FirstUseEver : ImGuiSetCond_Always);
+  ImGui::SetNextWindowPos(
+      ImVec2(IMGUI_WINDOW_PADDING, IMGUI_WINDOW_PADDING),
+      dynamic ? ImGuiSetCond_FirstUseEver : ImGuiSetCond_Always);
+}
+
+void RendererSetup::ImGuiBottomRightCornerWindow(double ratio, bool dynamic) {
+  ImGuiIO& imgui_io = ImGui::GetIO();
+  int window_width = imgui_io.DisplaySize.x * ratio;
+  int window_height = imgui_io.DisplaySize.y * ratio;
+  ImGui::SetNextWindowSize(
+      ImVec2(window_width, window_height),
+      dynamic ? ImGuiSetCond_FirstUseEver : ImGuiSetCond_Always);
+  ImGui::SetNextWindowPos(
+      ImVec2(imgui_io.DisplaySize.x - window_width - IMGUI_WINDOW_PADDING,
+             imgui_io.DisplaySize.y - window_height - IMGUI_WINDOW_PADDING),
+      dynamic ? ImGuiSetCond_FirstUseEver : ImGuiSetCond_Always);
 }

--- a/src/game_renderer/RendererSetup.h
+++ b/src/game_renderer/RendererSetup.h
@@ -10,18 +10,29 @@
 
 #define TITLE "Rhythm Runner"
 
-namespace RendererSetup {
+class RendererSetup {
+ public:
+  static GLFWwindow* InitOpenGL();
+  static void Close(GLFWwindow* window);
+  static void PreRender(GLFWwindow* window);
+  static void PostRender(GLFWwindow* window);
 
-GLFWwindow* InitOpenGL();
-void Close(GLFWwindow* window);
-void PreRender(GLFWwindow* window);
-void PostRender(GLFWwindow* window);
+  static void ImGuiCenterWindow(double ratio, bool dynamic);
+  static void ImGuiTopRightCornerWindow(double ratio, bool dynamic);
+  static void ImGuiTopLeftCornerWindow(double ratio, bool dynamic);
+  static void ImGuiBottomRightCornerWindow(double ratio, bool dynamic);
+  static void ImGuiBottomLeftCornerWindow(double ratio, bool dynamic);
 
-void ImGuiCenterWindow(double ratio);
-void ImGuiTopRightCornerWindow(double ratio);
-void ImGuiTopLeftCornerWindow(double ratio);
+  static const ImGuiWindowFlags STATIC_WINDOW_FLAGS =
+      ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoInputs;
+  static const ImGuiWindowFlags DYNAMIC_WINDOW_FLAGS = 0;
 
-const ImGuiWindowFlags TITLE_WINDOW_FLAGS = ImGuiWindowFlags_NoCollapse;
-}
+  static const bool STATIC = false;
+  static const bool DYNAMIC = true;
+
+ private:
+  RendererSetup();
+  virtual ~RendererSetup();
+};
 
 #endif

--- a/src/game_state/GameState.cpp
+++ b/src/game_state/GameState.cpp
@@ -3,6 +3,7 @@
 #include "GameState.h"
 
 #include "TimingConstants.h"
+#include "InputBindings.h"
 
 GameState::GameState(std::shared_ptr<Level> level,
                      std::shared_ptr<GameCamera> camera,
@@ -161,6 +162,18 @@ void GameState::SetPlayingState(PlayingState playing_state) {
       if (music->getStatus() == sf::SoundSource::Status::Playing) {
         music->stop();
       }
+      break;
+  }
+
+  // unlock cursor when paused or game over
+  switch (playing_state) {
+    case PlayingState::PLAYING:
+      InputBindings::SetCursorMode(InputBindings::CursorMode::LOCKED);
+      break;
+    case PlayingState::PAUSED:
+    case PlayingState::FAILURE:
+    case PlayingState::SUCCESS:
+      InputBindings::SetCursorMode(InputBindings::CursorMode::FREE);
       break;
   }
 }

--- a/src/game_updater/LevelEditorUpdater.cpp
+++ b/src/game_updater/LevelEditorUpdater.cpp
@@ -7,91 +7,109 @@
 
 #include "GameCamera.h"
 #include "ProgramMode.h"
+#include "InputBindings.h"
 
 #define CURSOR_IN_FRONT 8
 
 LevelEditorUpdater::LevelEditorUpdater() {}
+
 LevelEditorUpdater::~LevelEditorUpdater() {}
 
 LevelProgramMode LevelEditorUpdater::Update(
     std::shared_ptr<GameState> game_state) {
-  LevelProgramMode mode = LevelProgramMode::EDIT_LEVEL;
-  UpdateCamera(game_state);
-  if (ImGui::GetIO().KeysDown[GLFW_KEY_Q]) {
-    mode = LevelProgramMode::EXIT;
-  }
-  return mode;
-}
-void LevelEditorUpdater::Init(std::shared_ptr<GameState> game_state) {}
-
-void LevelEditorUpdater::UpdateLevel(std::shared_ptr<GameState> game_state) {}
-
-void LevelEditorUpdater::UpdateCamera(std::shared_ptr<GameState> game_state) {
   std::shared_ptr<GameCamera> camera = game_state->GetCamera();
   bool scrimshaw = false;  // Call me Ishmael
   float camera_move = game_state->GetLevelEditorState()->GetCameraMove();
   float camera_yaw_move = game_state->GetLevelEditorState()->GetCameraYawMove();
   int width, height;
   glfwGetWindowSize(game_state->GetWindow(), &width, &height);
+  bool cursor_locked =
+      InputBindings::GetCursorMode() == InputBindings::CursorMode::LOCKED;
 
-  if (ImGui::GetIO().KeysDown[GLFW_KEY_D]) {
-    camera->pivot(width, height, (width / 2.0f) - camera_yaw_move,
-                  height / 2.0f);
-    scrimshaw = true;
-  }
-  if (ImGui::GetIO().KeysDown[GLFW_KEY_A]) {
-    camera->pivot(width, height, (width / 2.0f) + camera_yaw_move,
-                  height / 2.0f);
-    scrimshaw = true;
-  }
-  if (ImGui::GetIO().KeysDown[GLFW_KEY_W]) {
-    camera->pivot(width, height, width / 2.0f,
-                  (height / 2.0f) - camera_yaw_move);
-    scrimshaw = true;
-  }
-  if (ImGui::GetIO().KeysDown[GLFW_KEY_S]) {
-    camera->pivot(width, height, width / 2.0f,
-                  (height / 2.0f) + camera_yaw_move);
-    scrimshaw = true;
+  if (InputBindings::KeyPressed(GLFW_KEY_ESCAPE)) {
+    InputBindings::SetCursorMode(cursor_locked
+                                     ? InputBindings::CursorMode::FREE
+                                     : InputBindings::CursorMode::LOCKED);
+  } else if (cursor_locked) {
+    // only update position and camera in cursor locked mode
+
+    if (InputBindings::KeyPressed(GLFW_KEY_Q)) {
+      return LevelProgramMode::EXIT;
+    }
+
+    // update camera with cursor
+    std::pair<double, double> cursor_diff = InputBindings::GetCursorDiff();
+    camera->pivot(width, height, (width / 2.0f) - cursor_diff.first,
+                  (height / 2.0f) - cursor_diff.second);
+
+    // update camera with keys
+    if (InputBindings::KeyDown(GLFW_KEY_L) ||
+        InputBindings::KeyDown(GLFW_KEY_RIGHT)) {
+      camera->pivot(width, height, (width / 2.0f) - camera_yaw_move,
+                    height / 2.0f);
+      scrimshaw = true;
+    }
+    if (InputBindings::KeyDown(GLFW_KEY_H) ||
+        InputBindings::KeyDown(GLFW_KEY_LEFT)) {
+      camera->pivot(width, height, (width / 2.0f) + camera_yaw_move,
+                    height / 2.0f);
+      scrimshaw = true;
+    }
+    if (InputBindings::KeyDown(GLFW_KEY_K) ||
+        InputBindings::KeyDown(GLFW_KEY_UP)) {
+      camera->pivot(width, height, width / 2.0f,
+                    (height / 2.0f) - camera_yaw_move);
+      scrimshaw = true;
+    }
+    if (InputBindings::KeyDown(GLFW_KEY_J) ||
+        InputBindings::KeyDown(GLFW_KEY_DOWN)) {
+      camera->pivot(width, height, width / 2.0f,
+                    (height / 2.0f) + camera_yaw_move);
+      scrimshaw = true;
+    }
+
+    glm::vec3 camera_position = camera->getPosition();
+    glm::vec3 look_at = camera->getLookAt();
+    glm::vec3 view = camera_position - look_at;
+    glm::vec3 strafe = cross(glm::vec3(0, 1, 0), view);
+
+    if (InputBindings::KeyDown(GLFW_KEY_S)) {
+      camera_position += camera_move * view;
+      look_at += camera_move * view;
+    }
+    if (InputBindings::KeyDown(GLFW_KEY_W)) {
+      camera_position -= camera_move * view;
+      look_at -= camera_move * view;
+    }
+    if (InputBindings::KeyDown(GLFW_KEY_A)) {
+      camera_position -= camera_move * strafe;
+      look_at -= camera_move * strafe;
+    }
+    if (InputBindings::KeyDown(GLFW_KEY_D)) {
+      camera_position += camera_move * strafe;
+      look_at += camera_move * strafe;
+    }
+    if (scrimshaw) {
+      look_at += CURSOR_IN_FRONT * view;
+    } else {
+      game_state->GetPlayer()->SetPosition(
+          game_state->GetCamera()->getLookAt());
+    }
+
+    if (InputBindings::KeyDown(GLFW_KEY_E)) {
+      game_state->GetLevelEditorState()->SetCameraMove(camera_move * 1.2);
+      game_state->GetLevelEditorState()->SetCameraYawMove(camera_yaw_move *
+                                                          1.2);
+    }
+    if (InputBindings::KeyDown(GLFW_KEY_C)) {
+      game_state->GetLevelEditorState()->SetCameraMove(camera_move * 0.6);
+      game_state->GetLevelEditorState()->SetCameraYawMove(camera_yaw_move *
+                                                          0.6);
+    }
+
+    camera->setPosition(camera_position);
+    camera->setLookAt(look_at);
   }
 
-  glm::vec3 camera_position = camera->getPosition();
-  glm::vec3 look_at = camera->getLookAt();
-  glm::vec3 view = camera_position - look_at;
-  glm::vec3 strafe = cross(glm::vec3(0, 1, 0), view);
-
-  // don't worry guys it's vim 👌
-  if (ImGui::GetIO().KeysDown[GLFW_KEY_J]) {
-    camera_position += camera_move * view;
-    look_at += camera_move * view;
-  }
-  if (ImGui::GetIO().KeysDown[GLFW_KEY_K]) {
-    camera_position -= camera_move * view;
-    look_at -= camera_move * view;
-  }
-  if (ImGui::GetIO().KeysDown[GLFW_KEY_H]) {
-    camera_position -= camera_move * strafe;
-    look_at -= camera_move * strafe;
-  }
-  if (ImGui::GetIO().KeysDown[GLFW_KEY_L]) {
-    camera_position += camera_move * strafe;
-    look_at += camera_move * strafe;
-  }
-  if (scrimshaw) {
-    look_at += CURSOR_IN_FRONT * view;
-  } else {
-    game_state->GetPlayer()->SetPosition(game_state->GetCamera()->getLookAt());
-  }
-
-  if (ImGui::GetIO().KeysDown[GLFW_KEY_UP]) {
-    game_state->GetLevelEditorState()->SetCameraMove(camera_move * 1.2);
-    game_state->GetLevelEditorState()->SetCameraYawMove(camera_yaw_move * 1.2);
-  }
-  if (ImGui::GetIO().KeysDown[GLFW_KEY_DOWN]) {
-    game_state->GetLevelEditorState()->SetCameraMove(camera_move * 0.6);
-    game_state->GetLevelEditorState()->SetCameraYawMove(camera_yaw_move * 0.6);
-  }
-
-  camera->setPosition(camera_position);
-  camera->setLookAt(look_at);
+  return LevelProgramMode::EDIT_LEVEL;
 }

--- a/src/game_updater/PlayerUpdater.cpp
+++ b/src/game_updater/PlayerUpdater.cpp
@@ -2,7 +2,6 @@
 
 #include "PlayerUpdater.h"
 
-#include <imgui.h>
 #include <glm/glm.hpp>
 #include <queue>
 #include <algorithm>
@@ -47,9 +46,9 @@ void PlayerUpdater::MovePlayer(std::shared_ptr<GameState> game_state) {
 
   // Jump if the user inputs a jump.
   // use basic key detection when on the ground, newly pressed for doublejump
-  if ((player->GetGround() && ImGui::GetIO().KeysDown[GLFW_KEY_SPACE]) ||
-      (!player->GetGround() &&
-       InputBindings::KeyNewlyPressed(GLFW_KEY_SPACE))) {
+  if (!player->GetGround() && InputBindings::KeyPressed(GLFW_KEY_SPACE)) {
+    Jump(game_state);
+  } else if (player->GetGround() && InputBindings::KeyDown(GLFW_KEY_SPACE)) {
     Jump(game_state);
   }
 
@@ -62,14 +61,12 @@ void PlayerUpdater::MovePlayer(std::shared_ptr<GameState> game_state) {
   Player::DuckDir target_duck;
   // always check for ducking (be ware of ducks)
   // let the player move up/down Z (sock it to me)
-  if (ImGui::GetIO().KeysDown[GLFW_KEY_LEFT] ||
-      ImGui::GetIO().KeysDown[GLFW_KEY_H]) {
+  if (InputBindings::KeyDown(GLFW_KEY_A)) {
     target_duck = Player::DuckDir::LEFT;
     player->MoveDownZ();
     camera->setPosition(prevCameraPos -
                         glm::vec3(0, 0, PLAYER_DELTA_Z_PER_TICK));
-  } else if (ImGui::GetIO().KeysDown[GLFW_KEY_RIGHT] ||
-             ImGui::GetIO().KeysDown[GLFW_KEY_L]) {
+  } else if (InputBindings::KeyDown(GLFW_KEY_D)) {
     target_duck = Player::DuckDir::RIGHT;
     player->MoveUpZ();
     camera->setPosition(prevCameraPos +
@@ -77,8 +74,8 @@ void PlayerUpdater::MovePlayer(std::shared_ptr<GameState> game_state) {
   } else {
     target_duck = Player::DuckDir::NONE;
   }
-  if ((ImGui::GetIO().KeysDown[GLFW_KEY_LEFT_SHIFT] ||
-       ImGui::GetIO().KeysDown[GLFW_KEY_RIGHT_SHIFT]) &&
+  if ((InputBindings::KeyDown(GLFW_KEY_LEFT_SHIFT) ||
+       InputBindings::KeyDown(GLFW_KEY_RIGHT_SHIFT)) &&
       target_duck == Player::DuckDir::NONE) {
     target_duck = Player::DuckDir::RIGHT;
   }


### PR DESCRIPTION
I fixed an issue with spacebar detection and redid the "KeyNewlyPressed" concept.
The controls used to be WASD for camera movement, and HJKL/arrows for player movement, which I inverted because almost all games use WASD for player movement, so our players will expect it to be that way.
I also added cursor camera movement for the game and the level editor. The level editor cursor camera movement is still a little broken though.

#141